### PR TITLE
issue-621 (ArachneUI) map BIGINT and NUMERIC types

### DIFF
--- a/src/main/java/com/odysseusinc/arachne/datanode/service/achilles/AchillesProcessors.java
+++ b/src/main/java/com/odysseusinc/arachne/datanode/service/achilles/AchillesProcessors.java
@@ -186,10 +186,15 @@ public class AchillesProcessors {
             case Types.DOUBLE:
             case Types.REAL:
             case Types.DECIMAL:
+            case Types.NUMERIC:
                 result = resultSet.getDouble(columnName);
+                break;
+            case Types.BIGINT:
+                result = resultSet.getLong(columnName);
                 break;
             default:
                 result = resultSet.getString(columnName);
+                LOGGER.warn("using default string type for mapping column: {} type: {} value: {}",columnName, type, result);
                 break;
         }
         return result;


### PR DESCRIPTION
Achilles reports during export to JSON uses string type by default.
In this PR i have add BIGINT mapping to LONG and NUMERIC to double