### PR TITLE
ARACHNE-2744 Cohort Characterization fails on BigQuery (#372)

### DIFF
--- a/src/main/resources/cc/r/runAnalysis.R
+++ b/src/main/resources/cc/r/runAnalysis.R
@@ -44,7 +44,8 @@ tryCatch({
     connectionDetails = connectionDetails,
     cdmSchema = cdmDatabaseSchema,
     vocabularySchema = cdmDatabaseSchema,
-    resultSchema = resultsDatabaseSchema
+    resultSchema = resultsDatabaseSchema,
+    tempSchema = resultsDatabaseSchema
   )
 
   runAnalysis(connectionDetails = connectionDetails,
@@ -59,7 +60,8 @@ tryCatch({
   cleanupCohortTable(
     connectionDetails = connectionDetails,
     resultSchema = resultsDatabaseSchema,
-    cohortTable = cohortTable
+    cohortTable = cohortTable,
+    tempSchema = resultsDatabaseSchema
   )
 }, finally = {
   remove.packages('{{packageName}}', lib = libs_local)


### PR DESCRIPTION
* ARACHNE-2744 Cohort Characterization fails on BigQuery
- generate sql with tempSchema(add tempSchema as argument to the SqlRender::translate method

* ARACHNE-2744 Cohort Characterization fails on BigQuery. fix review remarks
- set tempSchema