### PR TITLE
ARACHNE-2759 Errors during prod Upgrade

### DIFF
--- a/src/main/resources/db/migration/V20190708193000__fix-analysis-forighn-keys.sql
+++ b/src/main/resources/db/migration/V20190708193000__fix-analysis-forighn-keys.sql
@@ -1,0 +1,15 @@
+-- Remove unnecessary column constants
+-- There is no rename if exists/add if not exists operation in postgres, so I put a combination of drop/add operation
+-- at the end only analysis_files_analysis_id_fkey, analysis_code_files_analysis_id_fkey, analysis_state_journal_analysis_id_fkey constrains are going to remain
+
+ALTER TABLE analysis_files DROP CONSTRAINT IF EXISTS fk_analysis_id;
+ALTER TABLE analysis_code_files DROP CONSTRAINT IF EXISTS fk_analysis_id;
+ALTER TABLE analysis_state_journal DROP CONSTRAINT IF EXISTS fk_analysis_id;
+
+ALTER TABLE analysis_files DROP CONSTRAINT IF EXISTS analysis_files_analysis_id_fkey;
+ALTER TABLE analysis_code_files DROP CONSTRAINT IF EXISTS analysis_code_files_analysis_id_fkey;
+ALTER TABLE analysis_state_journal DROP CONSTRAINT IF EXISTS analysis_state_journal_analysis_id_fkey;
+
+ALTER TABLE analysis_files ADD CONSTRAINT analysis_files_analysis_id_fkey FOREIGN KEY (analysis_id) REFERENCES analyses(id);
+ALTER TABLE analysis_code_files ADD CONSTRAINT analysis_code_files_analysis_id_fkey FOREIGN KEY (analysis_id) REFERENCES analyses(id);
+ALTER TABLE analysis_state_journal ADD CONSTRAINT analysis_state_journal_analysis_id_fkey FOREIGN KEY (analysis_id) REFERENCES analyses(id);


### PR DESCRIPTION
ARACHNE-2759 Errors during prod Upgrade:
-  fix: violates foreign key constraint "fk_analysis_id"
The existing scripts manipulate with wrong analysis FK names. To prevent this situation we need to delete duplication and set proper names for FK
