### PR TITLE
ARACHNE-2768 Datanode 1.15 does not use proxy settings in case of ARA…

### DIFF
--- a/src/main/resources/application-base.yml
+++ b/src/main/resources/application-base.yml
@@ -222,3 +222,12 @@ authenticator:
           firstName: result.firstname
           middleName: result.middlename
           lastName: result.lastname
+          proxy:
+            enabled: ${proxy.enabled}
+            host: ${proxy.enabledForEngine}
+            port: ${proxy.host}
+            authEnabled: ${proxy.auth.enabled}
+            username: ${proxy.auth.username}
+            password: ${proxy.auth.password}
+
+


### PR DESCRIPTION
Arachne 2768 add proxy supprot for rest authentication