### PR TITLE
fix http issue with maven central

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -590,11 +590,6 @@
 
     <repositories>
         <repository>
-            <id>central</id>
-            <name>Central Repository</name>
-            <url>http://repo.maven.apache.org/maven2/</url>
-        </repository>
-        <repository>
             <id>odysseus.community.snapshots</id>
             <name>Odysseus community snapshots</name>
             <releases>


### PR DESCRIPTION
remove http://repo.maven.apache.org/maven2 from pom
http is no longer supported by maven central. Default repo points to the correct https version 
https://stackoverflow.com/a/59764670/11676