### PR TITLE
Switch tests to use Testcontainers instead of postgres database

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
         <java.version>1.8</java.version>
         <jjwt.version>0.10.8</jjwt.version>
         <postgresql.version>42.2.15</postgresql.version>
-        <javaDockerVersion>3.2.7</javaDockerVersion>
+        <javaDockerVersion>3.2.11</javaDockerVersion>
         <springRetryVersion>1.2.4.RELEASE</springRetryVersion>
         <build.number>${BUILD_NUMBER}</build.number>
         <build.id>${BUILD_TIMESTAMP}</build.id>
@@ -310,6 +310,24 @@
             <groupId>com.google.auth</groupId>
             <artifactId>google-auth-library-oauth2-http</artifactId>
             <version>0.20.0</version>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>testcontainers</artifactId>
+            <version>1.16.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>1.16.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>postgresql</artifactId>
+            <version>1.16.0</version>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 

--- a/src/test/java/com/odysseusinc/arachne/TestContainersInitializer.java
+++ b/src/test/java/com/odysseusinc/arachne/TestContainersInitializer.java
@@ -1,0 +1,31 @@
+package com.odysseusinc.arachne;
+
+import java.util.stream.Stream;
+import org.springframework.context.ApplicationContextInitializer;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.core.env.MapPropertySource;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.lifecycle.Startables;
+import org.testcontainers.shaded.com.google.common.collect.ImmutableMap;
+
+public class TestContainersInitializer implements ApplicationContextInitializer<ConfigurableApplicationContext> {
+    static PostgreSQLContainer<?> postgres = new PostgreSQLContainer<>();
+
+    private static void startContainers() {
+        Startables.deepStart(Stream.of(
+                postgres
+                // we can add further containers here, e.g. solr
+        )).join();
+    }
+
+    @Override
+    public void initialize(ConfigurableApplicationContext context) {
+        startContainers();
+        MapPropertySource testcontainers = new MapPropertySource("testcontainers", ImmutableMap.of(
+                "spring.datasource.url", postgres.getJdbcUrl(),
+                "spring.datasource.username", postgres.getUsername(),
+                "spring.datasource.password", postgres.getPassword()
+        ));
+        context.getEnvironment().getPropertySources().addFirst(testcontainers);
+    }
+}

--- a/src/test/java/com/odysseusinc/arachne/datanode/controller/AchillesControllerTest.java
+++ b/src/test/java/com/odysseusinc/arachne/datanode/controller/AchillesControllerTest.java
@@ -26,6 +26,7 @@ import com.github.springtestdbunit.DbUnitTestExecutionListener;
 import com.github.springtestdbunit.annotation.DatabaseOperation;
 import com.github.springtestdbunit.annotation.DatabaseSetup;
 import com.github.springtestdbunit.annotation.DbUnitConfiguration;
+import com.odysseusinc.arachne.TestContainersInitializer;
 import com.odysseusinc.arachne.commons.utils.ConverterUtils;
 import com.odysseusinc.arachne.datanode.model.achilles.AchillesJob;
 import com.odysseusinc.arachne.datanode.repository.AchillesJobRepository;
@@ -38,6 +39,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestExecutionListeners;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.context.support.DependencyInjectionTestExecutionListener;
@@ -66,6 +68,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
         "/data/achilles/achilles_jobs.xml"
 }, type = DatabaseOperation.CLEAN_INSERT)
 @Transactional
+@ContextConfiguration(initializers = TestContainersInitializer.class)
 public class AchillesControllerTest {
 
     private static final Long DATASOURCE_ID = 1L;

--- a/src/test/java/com/odysseusinc/arachne/datanode/controller/ValidatorTest.java
+++ b/src/test/java/com/odysseusinc/arachne/datanode/controller/ValidatorTest.java
@@ -30,6 +30,7 @@ import static org.testinfected.hamcrest.validation.ViolationMatchers.succeeds;
 import static org.testinfected.hamcrest.validation.ViolationMatchers.violates;
 import static org.testinfected.hamcrest.validation.ViolationMatchers.violation;
 
+import com.odysseusinc.arachne.TestContainersInitializer;
 import com.odysseusinc.arachne.commons.types.DBMSType;
 import com.odysseusinc.arachne.datanode.dto.datasource.CreateDataSourceDTO;
 import com.odysseusinc.arachne.datanode.model.datasource.DataSource;
@@ -43,6 +44,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestExecutionListeners;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.context.support.DependencyInjectionTestExecutionListener;
@@ -53,6 +55,7 @@ import org.testinfected.hamcrest.validation.ViolationMatchers;
 @SpringBootTest
 @ActiveProfiles("test")
 @TestExecutionListeners({DependencyInjectionTestExecutionListener.class})
+@ContextConfiguration(initializers = TestContainersInitializer.class)
 public class ValidatorTest {
 
     @Autowired

--- a/src/test/java/com/odysseusinc/arachne/datanode/service/DataNodeServiceNetworkTest.java
+++ b/src/test/java/com/odysseusinc/arachne/datanode/service/DataNodeServiceNetworkTest.java
@@ -28,6 +28,7 @@ import com.github.springtestdbunit.annotation.DatabaseOperation;
 import com.github.springtestdbunit.annotation.DatabaseSetup;
 import com.github.springtestdbunit.annotation.DatabaseTearDown;
 import com.github.springtestdbunit.annotation.DbUnitConfiguration;
+import com.odysseusinc.arachne.TestContainersInitializer;
 import com.odysseusinc.arachne.datanode.model.datanode.DataNode;
 import com.odysseusinc.arachne.datanode.model.user.User;
 import org.assertj.core.api.Assertions;
@@ -37,6 +38,7 @@ import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestExecutionListeners;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.context.support.DependencyInjectionTestExecutionListener;
@@ -56,6 +58,7 @@ import static org.hamcrest.core.IsInstanceOf.instanceOf;
         DbUnitTestExecutionListener.class})
 @DbUnitConfiguration(databaseConnection = "primaryDataSource")
 @DatabaseTearDown(value = "/data/dataset/empty-datanode.xml", type = DatabaseOperation.DELETE_ALL)
+@ContextConfiguration(initializers = TestContainersInitializer.class)
 public class DataNodeServiceNetworkTest {
 
     @Autowired

--- a/src/test/java/com/odysseusinc/arachne/datanode/service/DataNodeServiceStandaloneTest.java
+++ b/src/test/java/com/odysseusinc/arachne/datanode/service/DataNodeServiceStandaloneTest.java
@@ -34,6 +34,7 @@ import com.github.springtestdbunit.annotation.DatabaseOperation;
 import com.github.springtestdbunit.annotation.DatabaseSetup;
 import com.github.springtestdbunit.annotation.DatabaseTearDown;
 import com.github.springtestdbunit.annotation.DbUnitConfiguration;
+import com.odysseusinc.arachne.TestContainersInitializer;
 import com.odysseusinc.arachne.datanode.model.datanode.DataNode;
 import com.odysseusinc.arachne.datanode.model.user.User;
 import javax.ws.rs.NotFoundException;
@@ -45,6 +46,7 @@ import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestExecutionListeners;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.context.support.DependencyInjectionTestExecutionListener;
@@ -57,6 +59,7 @@ import org.springframework.test.context.support.DependencyInjectionTestExecution
         DbUnitTestExecutionListener.class })
 @DbUnitConfiguration(databaseConnection = "primaryDataSource")
 @DatabaseTearDown(value = "/data/dataset/empty-datanode.xml", type = DatabaseOperation.DELETE_ALL)
+@ContextConfiguration(initializers = TestContainersInitializer.class)
 public class DataNodeServiceStandaloneTest {
     @Autowired
     private DataNodeService dataNodeService;

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -12,9 +12,6 @@ spring.jpa.hibernate.ddl-auto=none
 spring.jpa.hibernate.connection.CharSet=utf8
 spring.jpa.hibernate.connection.characterEncoding=utf8
 spring.jpa.hibernate.connection.useUnicode=true
-spring.datasource.url=jdbc:postgresql://127.0.0.1:5433/datanode
-spring.datasource.username=ohdsi
-spring.datasource.password=ohdsi
 spring.datasource.driver-class-name=org.postgresql.Driver
 spring.datasource.connection-test-query=select 1
 


### PR DESCRIPTION
Also, java-docker is upgraded 3.2.7 -> 3.2.11 as the latter is required for testcontainers.