### PR TITLE
limits PLE with 1 core to prevent multi-thread issues

### DIFF
--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -45,8 +45,8 @@ authenticator:
   methods:
     rest-central:
       config:
-        url: https://localhost:8080/api/v1/auth/login
-        infoUrl: https://localhost:8080/api/v1/auth/me
+        url: https://localhost:8443/api/v1/auth/login
+        infoUrl: https://localhost:8443/api/v1/auth/me
 security.method: rest-central
 security.jwt.token.secretKey: ${datanode.jwt.secret}
 security.jwt.token.validityInSeconds: ${datanode.jwt.expiration}

--- a/src/main/resources/estimation/runAnalysis.R
+++ b/src/main/resources/estimation/runAnalysis.R
@@ -19,7 +19,9 @@ library(DatabaseConnector)
 library({{packageName}})
 
 tryCatch({
-        maxCores <- parallel::detectCores()
+        ## It's limited to a single core since parallel running tries to share connectionDetails
+        ## between multiple threads. One could be a cause of the analysis execution fail.
+        maxCores <- 1 # parallel::detectCores()
 
         dataSourceName <- (function(name) if (name == "") "default" else name)( Sys.getenv("DATA_SOURCE_NAME") )
         dbms <- Sys.getenv("DBMS_TYPE")


### PR DESCRIPTION
It's limited to a single core, since parallel running tries to share connectionDetails between multiple threads. 
One could be a cause of the analysis execution fail.